### PR TITLE
Add missing build command for frontend

### DIFF
--- a/get-started/installation.md
+++ b/get-started/installation.md
@@ -99,6 +99,7 @@ To build the Admin Interface, navigate to /frontend, install the requirements an
 ```sh
 cd /frontend
 npm install
+npm run build
 cd ..
 ```
 {% endstep %}


### PR DESCRIPTION
Needs npm run build in frontend folder in order to properly access /admin